### PR TITLE
Sync DHuS core version with DHuS distribution 2.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
       <dependency>
          <groupId>fr.gael.dhus</groupId>
          <artifactId>dhus-api</artifactId>
-         <version>1.11.0-RC06</version>
+         <version>1.11.0-osf</version>
       </dependency>
       <dependency>
          <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
The current version doesn't build when DHuS core 1.11.0-RC06 is not cached locally and it looks like this version is not easily obtainable anyway. This change will sync the required DHuS core version with DHuS distribution 2.7.7.